### PR TITLE
change: build.shをstatic以外をベースディレクトリに移動するように変更

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 python freeze.py
-mv build/*.html .
+find ./build/* -not -name static -exec mv {} . \;
 rm -rf build


### PR DESCRIPTION
前までのbuild.shだと, html拡張子のファイルをベースディレクトリ(run.pyとかがあるディレクトリ)に移動させていただけだった. このままだと, 今後htmlファイルを格納するディレクトリなどを使う際に, それが移動されない. static以外をベースディレクトリに移動するように変更することで, staticのコンフリクトを起こさないで, 所望のファイル及びディレクトリをベースディレクトリに移動させるようにした.

もしかしたら, このスクリプトでは今後不具合が出る可能性もあるので, 変更が必要になるかも.